### PR TITLE
Fix incorrect browser locale detection using wrong API

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -82,21 +82,6 @@ if (!function_exists('isLocaleEnabled')) {
     }
 }
 
-if (!function_exists('getBrowserLocaleOrMainLocale')) {
-    function getBrowserLocaleOrMainLocale(?Illuminate\Http\Request $request = null): string
-    {
-        $locale = null;
-        if ($request !== null) {
-            $locale = mb_substr((string) $request->header('Accept-Language'), 0, 2);
-        }
-        if ($locale && in_array($locale, enabledLocales(), true)) {
-            return $locale;
-        }
-
-        return mainLocale();
-    }
-}
-
 if (!function_exists('modules')) {
     /** @return array<string> */
     function modules(): array

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -83,10 +83,13 @@ if (!function_exists('isLocaleEnabled')) {
 }
 
 if (!function_exists('getBrowserLocaleOrMainLocale')) {
-    function getBrowserLocaleOrMainLocale(): string
+    function getBrowserLocaleOrMainLocale(?Illuminate\Http\Request $request = null): string
     {
-        $locale = mb_substr((string) getenv('HTTP_ACCEPT_LANGUAGE'), 0, 2);
-        if (in_array($locale, enabledLocales(), true)) {
+        $locale = null;
+        if ($request !== null) {
+            $locale = mb_substr((string) $request->header('Accept-Language'), 0, 2);
+        }
+        if ($locale && in_array($locale, enabledLocales(), true)) {
             return $locale;
         }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -75,7 +75,7 @@ return Application::configure(basePath: dirname(__DIR__))
             JavaScriptData::class,
             UserPrefs::class,
         ]);
-        $middleware->redirectGuestsTo(fn (Request $request): string => route(getBrowserLocaleOrMainLocale($request) . '::login'));
+        $middleware->redirectGuestsTo(fn (Request $request): string => route($request->getPreferredLanguage(enabledLocales()) . '::login'));
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->dontReport([]);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -75,7 +75,7 @@ return Application::configure(basePath: dirname(__DIR__))
             JavaScriptData::class,
             UserPrefs::class,
         ]);
-        $middleware->redirectGuestsTo(fn (Request $request): string => route(getBrowserLocaleOrMainLocale() . '::login'));
+        $middleware->redirectGuestsTo(fn (Request $request): string => route(getBrowserLocaleOrMainLocale($request) . '::login'));
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->dontReport([]);


### PR DESCRIPTION
The getBrowserLocaleOrMainLocale function incorrectly uses getenv('HTTP_ACCEPT_LANGUAGE') to retrieve the browser's language preference. This retrieves an environment variable, not an HTTP request header, so it will typically be empty in modern PHP setups.

Changed to use $request->header('Accept-Language') to properly get the browser's preferred language from the HTTP request headers.